### PR TITLE
Fix iOS sticky header gap with search header box-shadow overlay

### DIFF
--- a/src/chapter.njk
+++ b/src/chapter.njk
@@ -17,7 +17,7 @@ eleventyComputed:
 <div id="content" x-data="infiniteScrollContext" class="position-relative d-flex" data-book="{{ chapter.book }}" data-chapter="{{ chapter.chapter }}" data-chapter-slug="{{ chapter.slug }}" data-title="Armorer | {{ chapter.book }} {{ chapter.chapter }}" data-next-chapter="{{ chapter.nextChapter }}" data-prev-chapter="{{ chapter.prevChapter }}">
     <div x-intersect="chapterIntersected('{{ chapter.slug }}');" x-intersect.full="chapterIntersected('{{ chapter.slug }}', true);" class="pe-none position-absolute top-0 start-0 end-0" style="height: 50vh;"></div>
     <main class="container">
-        <header class="sticky-top bg-dark" style="top: -1px; padding-top: 1px;">
+        <header class="sticky-top bg-dark">
             <div class="fw-bold p-2">
                 <a href="{{bible.books[chapter.book].slug}}" class="link-light">{{ bible.books[chapter.book].title }}</a>
                 &nbsp;⟫&nbsp;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -61,6 +61,15 @@ body {
 }
 
 /**
+ * Prevent sub-pixel gap between search header and scroll container on iOS
+ */
+#site-wrapper>header {
+    position: relative;
+    z-index: 1030;
+    box-shadow: 0 2px 0 0 var(--bs-body-bg, #212529);
+}
+
+/**
  * Table of Contents
  */
 


### PR DESCRIPTION
The previous approach (top: -1px on the sticky header) didn't work because overflow:auto on the scroll container clips content at its boundary. Instead, add a 2px downward box-shadow to the search header with z-index: 1030 so it paints on top of the scroll container, covering any sub-pixel gap between the grid rows on iOS Safari.

Also keep bg-dark on the sticky <header> element (moved from inner div in previous commit) for cleaner markup.

https://claude.ai/code/session_019EXQ51jEVPb1jeivJzwJCz